### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # picoset
-A purpose-built Set implementation that outperforms HashSet at small scale — by design.
+A purpose-built set implementation that outperforms `HashSet` at small scale—by design.


### PR DESCRIPTION
## Summary
- fix capitalization and formatting for README description

## Testing
- `cargo test` (fails: could not find `Cargo.toml`)